### PR TITLE
feat: add `clean` cli command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,3 +26,4 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - The `get-nonce` command
 - The `get-balance` command
 - The `get-accounts` command
+- The `clean` command

--- a/README.md
+++ b/README.md
@@ -169,17 +169,6 @@ Nile-rs is a rust binary application, and while we plan to improve the distribut
     }
     ```
 
-12. Clean the workspace
-
-    ```
-    nile-rs clean
-    ```
-    ```
-    ✅ Removed deployments directory
-    ✅ Cleaned Scarb artifacts
-    ✨ Workspace clean, keep going!
-    ```
-
 ## License
 
 Nile is released under the MIT License.

--- a/README.md
+++ b/README.md
@@ -169,6 +169,17 @@ Nile-rs is a rust binary application, and while we plan to improve the distribut
     }
     ```
 
+12. Clean the workspace
+
+    ```
+    nile-rs clean
+    ```
+    ```
+    ✅ Removed deployments directory
+    ✅ Cleaned Scarb artifacts
+    ✨ Workspace clean, keep going!
+    ```
+
 ## License
 
 Nile is released under the MIT License.

--- a/docs/FEATURE_PARITY.md
+++ b/docs/FEATURE_PARITY.md
@@ -18,7 +18,7 @@
 | node                   |        | [#12](https://github.com/OpenZeppelin/nile-rs/issues/12)
 | compile                | ✅      | [#1](https://github.com/OpenZeppelin/nile-rs/issues/1)
 | run                    | ✅      | [#13](https://github.com/OpenZeppelin/nile-rs/issues/13)
-| clean                  |        | [#14](https://github.com/OpenZeppelin/nile-rs/issues/14)
+| clean                  | ✅      | [#14](https://github.com/OpenZeppelin/nile-rs/issues/14)
 | version                | ✅      |
 
 ## Scripting

--- a/src/bin/nile-rs/cli.rs
+++ b/src/bin/nile-rs/cli.rs
@@ -68,7 +68,7 @@ pub enum Commands {
     #[clap(about = "Query the registered accounts from the given network")]
     GetAccounts(GetAccounts),
 
-    #[clap(about = "Remove artifacts from workspace")]
+    #[clap(about = "Remove artifacts and contract deployments ")]
     Clean(Clean),
 }
 

--- a/src/bin/nile-rs/cli.rs
+++ b/src/bin/nile-rs/cli.rs
@@ -1,6 +1,6 @@
 use crate::commands::{
-    Call, Compile, CounterfactualAddress, Declare, DeclareV1, Deploy, GetAccounts, GetBalance,
-    GetNonce, Init, LegacyDeploy, Run, Send, Setup, Status,
+    Call, Clean, Compile, CounterfactualAddress, Declare, DeclareV1, Deploy, GetAccounts,
+    GetBalance, GetNonce, Init, LegacyDeploy, Run, Send, Setup, Status,
 };
 use clap::{Parser, Subcommand};
 
@@ -67,6 +67,9 @@ pub enum Commands {
 
     #[clap(about = "Query the registered accounts from the given network")]
     GetAccounts(GetAccounts),
+
+    #[clap(about = "Remove artifacts from workspace")]
+    Clean(Clean),
 }
 
 #[test]

--- a/src/bin/nile-rs/commands.rs
+++ b/src/bin/nile-rs/commands.rs
@@ -1,4 +1,5 @@
 mod call;
+mod clean;
 mod compile;
 mod counterfactual_address;
 mod declare;
@@ -14,6 +15,7 @@ mod setup;
 mod status;
 
 pub use call::Call;
+pub use clean::Clean;
 pub use compile::Compile;
 pub use counterfactual_address::CounterfactualAddress;
 pub use declare::{DeclareV1, DeclareV2 as Declare};

--- a/src/bin/nile-rs/commands/clean.rs
+++ b/src/bin/nile-rs/commands/clean.rs
@@ -19,20 +19,45 @@ pub struct Clean {
         default_value = "./Scarb.toml"
     )]
     pub manifest_path: String,
+
+    // Add the all flag
+    #[clap(help = "Remove registered accounts as well", long = "all")]
+    pub all: bool,
 }
 
 #[async_trait]
 impl CliCommand for Clean {
     type Output = ();
 
-    // Remove artifacts from workspace
+    // Remove artifacts and contract deployments
     async fn run(&self) -> Result<Self::Output> {
         // Remove the deployments directory
         let nile_config = NileConfig::get()?;
         let deployments_dir = nile_config.deployments_dir;
         if PathBuf::from(&deployments_dir).exists() {
-            fs::remove_dir_all(deployments_dir).unwrap();
-            println!("✅ Removed deployments directory");
+            // Check if the all flag is set
+            if self.all {
+                fs::remove_dir_all(deployments_dir).unwrap();
+                println!("✅ Removed deployments directory");
+            } else {
+                // Remove only contract deployment files and leave accounts files
+                let deployment_files = fs::read_dir(&deployments_dir)?
+                    .filter_map(Result::ok)
+                    .filter(|entry| {
+                        entry.path().extension().and_then(|ext| ext.to_str()) == Some("json")
+                            && entry
+                                .path()
+                                .file_stem()
+                                .and_then(|stem| stem.to_str())
+                                .map_or(false, |stem| !stem.ends_with("accounts"))
+                    })
+                    .collect::<Vec<_>>();
+
+                for file in deployment_files {
+                    fs::remove_file(file.path())?;
+                }
+                println!("✅ Removed contract deployments");
+            }
         } else {
             println!("🟡 No deployments to delete");
         }

--- a/src/bin/nile-rs/commands/clean.rs
+++ b/src/bin/nile-rs/commands/clean.rs
@@ -1,0 +1,63 @@
+use anyhow::{Context, Result};
+use scarb::core::Config;
+use scarb::ops;
+use std::fs;
+use std::path::PathBuf;
+use std::thread;
+
+use super::CliCommand;
+use async_trait::async_trait;
+use clap::Parser;
+use nile_rs::config::Config as NileConfig;
+
+#[derive(Parser, Debug)]
+pub struct Clean {
+    #[clap(
+        help = "Scarb manifest path",
+        long,
+        short,
+        default_value = "./Scarb.toml"
+    )]
+    pub manifest_path: String,
+}
+
+#[async_trait]
+impl CliCommand for Clean {
+    type Output = ();
+
+    // Remove artifacts from workspace
+    async fn run(&self) -> Result<Self::Output> {
+        // Remove the deployments directory
+        let nile_config = NileConfig::get()?;
+        let deployments_dir = nile_config.deployments_dir;
+        if PathBuf::from(&deployments_dir).exists() {
+            fs::remove_dir_all(deployments_dir).unwrap();
+            println!("✅ Removed deployments directory");
+        } else {
+            println!("🟡 No deployments to delete");
+        }
+
+        // Remove build artifacts using Scarb
+        let src = PathBuf::from(&self.manifest_path);
+        let abs_path = fs::canonicalize(src).with_context(|| {
+            format!(
+                "Unable to clean from the Scarb manifest file: {}",
+                &self.manifest_path
+            )
+        })?;
+
+        let thread = thread::spawn(move || {
+            let scarb_config_builder = Config::builder(abs_path.to_str().unwrap());
+            let scarb_config = scarb_config_builder.build().unwrap();
+            match ops::clean(&scarb_config) {
+                Ok(_) => println!("✅ Cleaned Scarb artifacts"),
+                Err(_) => println!("🟡 No artifacts to clean"),
+            }
+        });
+
+        thread.join().expect("Cleaning thread panicked");
+
+        println!("✨ Workspace clean, keep going!");
+        Ok(())
+    }
+}

--- a/src/bin/nile-rs/main.rs
+++ b/src/bin/nile-rs/main.rs
@@ -62,6 +62,9 @@ async fn main() -> Result<()> {
         cli::Commands::GetAccounts(cmd) => {
             cmd.run().await?;
         }
+        cli::Commands::Clean(cmd) => {
+            cmd.run().await?;
+        }
     };
 
     Ok(())

--- a/tests/clean.rs
+++ b/tests/clean.rs
@@ -1,14 +1,78 @@
+use assert_fs::{prelude::PathCopy, TempDir};
 use nile_test_utils::{expected_stdout, snapbox::get_snapbox};
 
+use std::{fs, path::Path};
+
+// Helper function to create a temp dir with a Scarb.toml file
+fn temp_dir_with_scarb() -> TempDir {
+    let temp = assert_fs::TempDir::new().unwrap();
+    temp.copy_from("./tests/fixtures", &["Scarb.toml"]).unwrap();
+    temp
+}
+
+// Helper function to copy artifacts and contract & account deployments
+fn copy_artifacts(temp: &TempDir) {
+    let fixtures = Path::new("./tests/fixtures");
+    // Copy fixture contract deployments
+    temp.copy_from(fixtures, &["deployments/empty.contracts.json"])
+        .unwrap();
+    // Copy fixture account deployments
+    temp.copy_from(fixtures, &["deployments/localhost.accounts.json"])
+        .unwrap();
+    // Copy fixture artifact
+    temp.copy_from(fixtures, &["artifacts/cairo0_contract.json"])
+        .unwrap();
+    // Move to target/release
+    let compilation_path = temp.path().join("target/release");
+    fs::create_dir_all(&compilation_path).unwrap();
+    fs::copy(
+        fixtures.join("artifacts/cairo0_contract.json"),
+        compilation_path.join("cairo0_contract.json"),
+    )
+    .unwrap();
+}
+
 #[test]
-fn test_clean() {
-    let pt = assert_fs::TempDir::new().unwrap();
+fn test_clean_none() {
+    let temp = temp_dir_with_scarb();
 
     let assert = get_snapbox()
         .arg("clean")
-        .current_dir(&pt)
+        .current_dir(&temp)
+        .assert()
+        .success();
+
+    assert.stdout_eq(expected_stdout("clean_none"));
+}
+
+#[test]
+fn test_clean() {
+    let temp = temp_dir_with_scarb();
+
+    // Copy artifacts and contract and account deployments
+    copy_artifacts(&temp);
+
+    let assert = get_snapbox()
+        .arg("clean")
+        .current_dir(&temp)
         .assert()
         .success();
 
     assert.stdout_eq(expected_stdout("clean"));
+}
+
+#[test]
+fn test_clean_all() {
+    let temp = temp_dir_with_scarb();
+
+    // Copy artifacts and contract and account deployments
+    copy_artifacts(&temp);
+
+    let assert = get_snapbox()
+        .args(["clean", "--all"])
+        .current_dir(&temp)
+        .assert()
+        .success();
+
+    assert.stdout_eq(expected_stdout("clean_all"));
 }

--- a/tests/clean.rs
+++ b/tests/clean.rs
@@ -13,16 +13,17 @@ fn temp_dir_with_scarb() -> TempDir {
 // Helper function to copy artifacts and contract & account deployments
 fn copy_artifacts(temp: &TempDir) {
     let fixtures = Path::new("./tests/fixtures");
-    // Copy fixture contract deployments
-    temp.copy_from(fixtures, &["deployments/empty.contracts.json"])
-        .unwrap();
-    // Copy fixture account deployments
-    temp.copy_from(fixtures, &["deployments/localhost.accounts.json"])
-        .unwrap();
-    // Copy fixture artifact
-    temp.copy_from(fixtures, &["artifacts/cairo0_contract.json"])
-        .unwrap();
-    // Move to target/release
+    // Copy fixture artifacts
+    temp.copy_from(
+        fixtures,
+        &[
+            "deployments/empty.contracts.json",
+            "deployments/localhost.accounts.json",
+            "artifacts/cairo0_contract.json",
+        ],
+    )
+    .unwrap();
+    // Move compiled contract to target/release
     let compilation_path = temp.path().join("target/release");
     fs::create_dir_all(&compilation_path).unwrap();
     fs::copy(

--- a/tests/clean.rs
+++ b/tests/clean.rs
@@ -1,0 +1,14 @@
+use nile_test_utils::{expected_stdout, snapbox::get_snapbox};
+
+#[test]
+fn test_clean() {
+    let pt = assert_fs::TempDir::new().unwrap();
+
+    let assert = get_snapbox()
+        .arg("clean")
+        .current_dir(&pt)
+        .assert()
+        .success();
+
+    assert.stdout_eq(expected_stdout("clean"));
+}

--- a/tests/fixtures/Scarb.toml
+++ b/tests/fixtures/Scarb.toml
@@ -1,0 +1,15 @@
+[package]
+name = "nile_project" # the name of the package
+version = "0.1.0"    # the current version, obeying semver
+
+[[target.starknet-contract]]
+
+[tool.nile_rs]
+artifacts_dir = "./target/release"
+contracts_dir = "./src"
+
+# This is the default localhost configuration, the value is added as an example
+# and you can safely remove it.
+networks = [
+    { name = "localhost", gateway = "http://127.0.0.1:5050/gateway", chain_id = "1536727068981429685321" }
+]

--- a/tests/fixtures/stdout/clean.stdout
+++ b/tests/fixtures/stdout/clean.stdout
@@ -1,0 +1,3 @@
+🟡 No deployments to delete
+🟡 No artifacts to clean
+✨ Workspace clean, keep going!

--- a/tests/fixtures/stdout/clean_all.stdout
+++ b/tests/fixtures/stdout/clean_all.stdout
@@ -1,3 +1,3 @@
-✅ Removed contract deployments
+✅ Removed deployments directory
 ✅ Cleaned Scarb artifacts
 ✨ Workspace clean, keep going!

--- a/tests/fixtures/stdout/clean_none.stdout
+++ b/tests/fixtures/stdout/clean_none.stdout
@@ -1,0 +1,3 @@
+🟡 No deployments to delete
+🟡 No artifacts to clean
+✨ Workspace clean, keep going!


### PR DESCRIPTION
## Description:

This pr implements the following
- `clean` command to remove artifacts from the workspace 
- Removes the compiled contracts using `scarb`
- Update the documentation
- Fix #14 

## Screenshots:

When there are artifacts with no `--all` flag: only contract deployments are deleted

<img width="248" alt="image" src="https://user-images.githubusercontent.com/35031356/230071197-cdcd55b0-d5a8-4f65-b799-c22c9c18126c.png">

When there are artifacts with `--all` flag: entire deployments directory is deleted (this includes account deployments)

<img width="248" alt="image" src="https://user-images.githubusercontent.com/35031356/230071692-33baa867-e1ab-4533-8214-c2251d416364.png">

When there are no artifacts

![image](https://user-images.githubusercontent.com/35031356/230043568-e26828e5-f0b3-4ba6-aab1-a80fea4e24c9.png)
